### PR TITLE
reomves redundant newletter component from about and home pages

### DIFF
--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -50,11 +50,6 @@ const AboutPage: React.FC = () => {
           At Café Fausse, we are devoted to delivering unforgettable dining experiences through excellent food, exceptional service, and a commitment to locally sourced ingredients. We take pride in every dish, ensuring each plate reflects our passion for culinary art.
         </p>
       </section>
-      
-      {/* Newsletter Signup */}
-      <div className="newsletter-container">
-        <NewsletterSignup className="about-newsletter" />
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -78,11 +78,6 @@ const HomePage: React.FC = () => {
           </Link>
         </div>
       </section>
-      
-      {/* Newsletter signup component */}
-      <section className="newsletter-section">
-        <NewsletterSignup className="home-newsletter" />
-      </section>
     </div>
   );
 };


### PR DESCRIPTION
this component is at the bottom of the page right about the footer which also contains the newletter component. A better user experience would just have this in the footer.